### PR TITLE
Remove R2 criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ Se [OS2iot Governance Report.md](https://github.com/OS2iot/OS2IoT-docs/blob/mast
 |     |  #  | Krav | Henvisning | Niveau | 
 | --- | --- | --- | --- | --- |
 | [x] | R1 | Løsningen skaber lokal værdi | Hvordan?  | 0 |
-| [] | R2 | Løsningen skaber potentielt værdi for andre | Hvordan?  | 1 | 
-| [] | R3 | Løsningen er accepteret af lokal linjeledelse | fx tilslutningserklæring | 2 |
-| [] | R4 | _Løsningen har tværkommunal potentiale (anbefaling)_ | Hvordan? | 2 |
-| [] | R5 | Ophæng til nationale strategier er til stede | Hvordan/hvilke? | 3 |
+| [] | R2 | Løsningen er accepteret af lokal linjeledelse | fx tilslutningserklæring | 2 |
+| [] | R3 | _Løsningen har tværkommunal potentiale (anbefaling)_ | Hvordan? | 2 |
+| [] | R4 | Ophæng til nationale strategier er til stede | Hvordan/hvilke? | 3 |
 
 ## FORMKRAV
 


### PR DESCRIPTION
R2 criteria removed and the following "R" criterias renamed accordingly to avoid a gap in the "R" criterias from 1 to 3.